### PR TITLE
style and links fixes in chatroom plus extracting general css to sepa…

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 // Graphical variables
+@import "config/reset";
 @import "config/fonts";
 @import "config/colors";
 @import "config/bootstrap_variables";

--- a/app/assets/stylesheets/config/_reset.scss
+++ b/app/assets/stylesheets/config/_reset.scss
@@ -1,0 +1,10 @@
+html, body{
+  height: 100%; min-height:100%;
+  margin-bottom: 70px;
+  margin-top: 50px;
+}
+
+// removing the default underline decoration on links
+a {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/pages/_chatroom.scss
+++ b/app/assets/stylesheets/pages/_chatroom.scss
@@ -42,7 +42,7 @@
 .hbuddy-chatroom {
   background: white;
   margin-top: 9px;
-  height: calc(100vh - 75px);
+  height: calc(100vh - 120px);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -81,7 +81,8 @@
     .message_content {
       margin-bottom: 0 !important;
     }
-    textarea.form-control {      
+    textarea.form-control {
+      height: 45px;   
       background: transparent;
       border-radius: 10rem 0 0 10rem;
       border: none;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,11 +1,3 @@
-Specific CSS for your home-page
-
-html, body{
-height: 100%; min-height:100%;
-margin-bottom: 70px;
-margin-top: 50px;
-}
-
 .hbuddy-home-bg {
   background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url("https://www.zupimages.net/up/23/07/6nl3.jpg");
   background-position: center;

--- a/app/views/chatrooms/index.html.erb
+++ b/app/views/chatrooms/index.html.erb
@@ -29,8 +29,8 @@
         <ul class="hbuddy-message-list">
           <% @chatrooms.each do |chatroom| %>
             <li>
-              <div class="d-flex py-3 align-items-center">
-                <%= link_to chatroom_path(chatroom) do %>
+              <%= link_to chatroom_path(chatroom), class: "text-decoration-none" do %>
+                <div class="d-flex py-3 align-items-center">           
                   <% if chatroom.user1 == @user %>
                     <% if chatroom.user2.avatar.attached? %>
                       <%= cl_image_tag chatroom.user2.avatar.key, class: "hbuddy-match-avatar", width:50, height:50 %>
@@ -39,18 +39,18 @@
                     <% if chatroom.user2.avatar.attached? %>
                       <%= cl_image_tag chatroom.user1.avatar.key, class: "hbuddy-match-avatar", width:50, height:50 %>
                     <% end %>
-                  <% end %>
-                <% end %>
-                <div class="hbuddy-message-preview">
-                  <% last_message = Message.where(chatroom_id: chatroom.id).last %>
-                  <% if last_message != nil %>
-                    <p class="first-name"><%= User.find(last_message.user_id).first_name %></p>
-                    <p class="message"><%= last_message.content %></p>
-                  <% else %>
-                    <p class="my-auto">No messages exchanged</p>
-                  <% end %>
+                  <% end %>                
+                  <div class="hbuddy-message-preview">
+                    <% last_message = Message.where(chatroom_id: chatroom.id).last %>
+                    <p class="first-name"><%= User.find(chatroom.other_user(@user)).first_name %></p>
+                    <% if last_message != nil %>                      
+                      <p class="message"><%= last_message.content %></p>
+                    <% else %>
+                      <p class="my-auto fst-italic text-danger fw-light"><small>No messages exchanged</small></p>
+                    <% end %>
+                  </div>
                 </div>
-              </div>
+              <% end %>
             </li>
           <% end %>
         </ul>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -26,7 +26,7 @@
 
   <%= simple_form_for [@chatroom, @message], html: { data: { action: "turbo:submit-end->chatroom-subscription#resetForm" }, class: "d-flex hbuddy-message-input" } do |f| %>
     <%= f.input :content, label: false, placeholder: "Send message", wrapper_html: {class: "flex-grow-1"} %>
-    <%= button_tag(type: 'submit', class: "btn btn-primary") do %>
+    <%= button_tag(type: 'submit', class: "btn btn-primary d-flex align-items-center") do %>
       <span class="material-symbols-outlined">send</span>
     <% end %>
   <% end %>


### PR DESCRIPTION
- Added different style to distinguish a chatroom with no messages in Chatroom index
- Changed link from the user avatar to wrap the whole block [Avatar + name & msg preview]
- Made the input height smaller in the chatroom and centered the send icon inside the btn
- Extracted general styles applied on body and html tag and a in a separate file for easier tracking of this type of syle
`_reset.scss added in stylesheets/conf` 
@lenaa1208 j'ai sortie ces lignes de _home.scss et mis dans _reset.scss, vu que c'est des styles generique à toute l'application il vaut mieux les grouper dans un fichier dédié à ça.